### PR TITLE
fix(UI): remove pagination icons if there is only one page in datatab…

### DIFF
--- a/resources/assets/js/custom.js
+++ b/resources/assets/js/custom.js
@@ -165,3 +165,19 @@ window.displaySuccessMessage = function (message) {
         position: 'top-right',
     });
 };
+
+$(function () {
+    $(".dataTables_length").css('padding-top', '6px');
+    $(".dataTables_info").css('padding-top', '24px');
+});
+
+$.extend($.fn.dataTable.defaults, {
+    drawCallback: function (settings) {
+        let thisTableId = settings.sTableId;
+        if (settings.fnRecordsDisplay() > settings._iDisplayLength) {
+            $('#' + thisTableId + '_paginate').show();
+        } else {
+            $('#' + thisTableId + '_paginate').hide();
+        }
+    }
+});

--- a/resources/assets/js/task/task_detail.js
+++ b/resources/assets/js/task/task_detail.js
@@ -239,10 +239,11 @@ Dropzone.options.dropzone = {
         let newFileName = fileNameExtArr[0];
         let newFileExt = fileNameExtArr[1];
         let prevFileName = fileuploded.innerHTML.split('.')[0];
+        let fileUrl = attachmentUrl + fileName;
         fileuploded.innerHTML = fileName;
 
-        $(file.previewTemplate).find('.dz-remove').attr('data-file-id', attachment.id);
-        $(file.previewTemplate).find('.dz-remove').attr('data-file-url', attachment.file_url);
+        $(".dz-preview:last-child").children(':last-child').attr('data-file-id', attachment.id);
+        $(".dz-preview:last-child").children(':last-child').attr('data-file-url', attachment.file_url);
         if($.inArray(newFileExt,['jpg','jpge','png']) > -1) {
             $(".previewEle").find('.' + prevFileName).attr('href', attachment.file_url);
             $(".previewEle").find('.' + prevFileName).attr('class', newFileName);

--- a/resources/assets/js/task/task_detail.js
+++ b/resources/assets/js/task/task_detail.js
@@ -239,11 +239,10 @@ Dropzone.options.dropzone = {
         let newFileName = fileNameExtArr[0];
         let newFileExt = fileNameExtArr[1];
         let prevFileName = fileuploded.innerHTML.split('.')[0];
-        let fileUrl = attachmentUrl + fileName;
         fileuploded.innerHTML = fileName;
 
-        $(".dz-preview:last-child").children(':last-child').attr('data-file-id', attachment.id);
-        $(".dz-preview:last-child").children(':last-child').attr('data-file-url', attachment.file_url);
+        $(file.previewTemplate).find('.dz-remove').attr('data-file-id', attachment.id);
+        $(file.previewTemplate).find('.dz-remove').attr('data-file-url', attachment.file_url);
         if($.inArray(newFileExt,['jpg','jpge','png']) > -1) {
             $(".previewEle").find('.' + prevFileName).attr('href', attachment.file_url);
             $(".previewEle").find('.' + prevFileName).attr('class', newFileName);


### PR DESCRIPTION
### Data table UI enhancement [(issue)](https://gitlab.com/infy-apps/infy-tracker-issues/issues/83)
- Pagination should be displayed when the page is more than one
- Align table information with pagination section.
- Align pagination drop-down options with the search box.

**UI Ref:**
![Datatable UI issue](https://user-images.githubusercontent.com/51854283/64097580-42b34c00-cd82-11e9-8988-be5b6ffebb6a.PNG)
