### PR TITLE
fix(task-detail): remove file when multiple file upload using dropzon

### DIFF
--- a/resources/assets/js/task/task_detail.js
+++ b/resources/assets/js/task/task_detail.js
@@ -239,11 +239,10 @@ Dropzone.options.dropzone = {
         let newFileName = fileNameExtArr[0];
         let newFileExt = fileNameExtArr[1];
         let prevFileName = fileuploded.innerHTML.split('.')[0];
-        let fileUrl = attachmentUrl + fileName;
         fileuploded.innerHTML = fileName;
 
-        $(".dz-preview:last-child").children(':last-child').attr('data-file-id', attachment.id);
-        $(".dz-preview:last-child").children(':last-child').attr('data-file-url', attachment.file_url);
+        $(file.previewTemplate).find('.dz-remove').attr('data-file-id', attachment.id);
+        $(file.previewTemplate).find('.dz-remove').attr('data-file-url', attachment.file_url);
         if($.inArray(newFileExt,['jpg','jpge','png']) > -1) {
             $(".previewEle").find('.' + prevFileName).attr('href', attachment.file_url);
             $(".previewEle").find('.' + prevFileName).attr('class', newFileName);


### PR DESCRIPTION
### Bugfix: [(issue)](https://gitlab.com/infy-apps/infy-tracker-issues/issues/68)
- In Task-detail screen when upload multiple files using dropzone only one file was able to remove, now we can remove any file.
