### PR TITLE
feat(time-entry): reduce width of time entry detail pop up in task de…

### DIFF
--- a/resources/views/tasks/time_tracking_modal.blade.php
+++ b/resources/views/tasks/time_tracking_modal.blade.php
@@ -14,7 +14,7 @@
                         <th scope="col">Note</th>
                         <th scope="col">Activity</th>
                         <th scope="col" class="text-nowrap text-center">Tracked By</th>
-                        <th scope="col" class="text-nowrap text-center">Time (Minutes)</th>
+                        <th scope="col" class="text-nowrap text-center">Time (Mins)</th>
                     </tr>
                     </thead>
                     <tbody>
@@ -22,7 +22,7 @@
                         <tr>
                             <td>{!! $entry->note !!}</td>
                             <td>{{$entry->activityType->name}}</td>
-                            <td class="text-nowrap text-center">{{$entry->user->name}}</td>
+                            <td class="text-nowrap text-center"><img src="{{$entry->user->img_avatar}}"></td>
                             <td class="text-nowrap text-center">{{$entry->duration}}</td>
                         </tr>
                     @endforeach


### PR DESCRIPTION
Enhancement: 
- reduce width of time entry detail pop up in task detail screen.
   - Change Profile avatar instead of  tracked by column
   - Change Time(Mins) instead of minutes as shown in image

Ref:
![time tracking modal](https://user-images.githubusercontent.com/51854283/64425507-7e734c00-d0c9-11e9-9829-f19dc475a56d.PNG)

issue link: https://gitlab.com/infy-apps/infy-tracker-issues/issues/96
