### PR TITLE
fix(task): solve task tag edit issue

### DIFF
--- a/app/Http/Controllers/TaskController.php
+++ b/app/Http/Controllers/TaskController.php
@@ -8,6 +8,7 @@ use App\Models\Project;
 use App\Models\Task;
 use App\Models\TaskAttachment;
 use App\Queries\TaskDataTable;
+use App\Repositories\TagRepository;
 use App\Repositories\TaskRepository;
 use App\Repositories\UserRepository;
 use DataTables;
@@ -146,7 +147,12 @@ class TaskController extends AppBaseController
         $task->taskAssignee;
         $task->attachments;
 
-        return $this->sendResponse($task, 'Task retrieved successfully.');
+        /** @var TagRepository $tagRepo */
+        $tagRepo = app(TagRepository::class);
+        $data['tags'] = $tagRepo->getTagList();
+        $data['task'] = $task;
+
+        return $this->sendResponse($data, 'Task retrieved successfully.');
     }
 
     /**

--- a/resources/assets/js/task/task.js
+++ b/resources/assets/js/task/task.js
@@ -229,7 +229,13 @@ $(document).on('click', '.edit-btn', function (event) {
         type: 'GET',
         success: function (result) {
             if (result.success) {
-                let task = result.data;
+                let task = result.data.task;
+                let allTags = result.data.tags;
+                $('#editTagIds').empty();
+                $.each(allTags, function (i, e) {
+                    $('#editTagIds').append($('<option>', {value: i, text: e}));
+                });
+
                 let desc = $('<div/>').html(task.description).text();
                 CKEDITOR.instances.editDesc.setData(desc);
                 $('#tagId').val(task.id);

--- a/resources/views/tasks/edit_modal.blade.php
+++ b/resources/views/tasks/edit_modal.blade.php
@@ -37,7 +37,7 @@
                     </div>
                     <div class="form-group col-sm-6">
                         {!! Form::label('tags', 'Tags') !!}
-                        {!! Form::select('tags[]',$tags, null, ['class' => 'form-control','id'=>'editTagIds', 'multiple' => true]) !!}
+                        {!! Form::select('tags[]',[], null, ['class' => 'form-control','id'=>'editTagIds', 'multiple' => true]) !!}
                     </div>
                 </div>
                 <div class="row">

--- a/tests/Controllers/TaskControllerTest.php
+++ b/tests/Controllers/TaskControllerTest.php
@@ -8,6 +8,7 @@ use App\Models\Tag;
 use App\Models\Task;
 use App\Models\TimeEntry;
 use App\Models\User;
+use App\Repositories\TagRepository;
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Tests\TestCase;
 use Tests\Traits\MockRepositories;
@@ -138,16 +139,21 @@ class TaskControllerTest extends TestCase
         $task->taskAssignee()->sync([$farhan->id]);
 
         /** @var Tag $tag */
-        $tag = factory(Tag::class)->create();
-        $task->tags()->sync([$tag->id]);
+        $tag = factory(Tag::class)->times(2)->create();
+        $task->tags()->sync([$tag[0]->id]);
+
+        /** @var TagRepository $tagRepo */
+        $tagRepo = app(TagRepository::class);
+        $data['tags'] = $tagRepo->getTagList()->toArray();
+        $data['task'] = $task->toArray();
 
         $response = $this->getJson(route('tasks.edit', $task->id));
 
-        $this->assertSuccessDataResponse($response, $task->toArray(), 'Task retrieved successfully.');
+        $this->assertSuccessDataResponse($response, $data, 'Task retrieved successfully.');
 
-        $data = $response->original['data'];
+        $data = $response->original['data']['task'];
         $this->assertEquals($task->project_id, $data['project']['id']);
-        $this->assertEquals($tag->id, $data['tags'][0]['id']);
+        $this->assertEquals($tag[0]->id, $data['tags'][0]['id']);
         $this->assertEquals($farhan->id, $data['taskAssignee'][0]['id']);
     }
 


### PR DESCRIPTION
Fix: task edit
-  At time of edit task, if we create a new tag and complete editing task. after that, if we again edit the same task without page refresh than that tag will not come, and again we try to create the same tag than Integrity constraint violation error was coming, Fixed this issue.

issue link: https://gitlab.com/infy-apps/infy-tracker-issues/issues/114