### PR TITLE
feat(task-detail): fix dropzon image overlapping issue.

### DIFF
--- a/resources/assets/style/sass/style.scss
+++ b/resources/assets/style/sass/style.scss
@@ -432,7 +432,7 @@ table.dataTable {
     bottom: 105px;
     right: 454px;
     width: 318px;
-    z-index: 2;
+    z-index: 1001;
 }
 
 .time-tracker-modal {
@@ -473,7 +473,7 @@ table.dataTable {
     position: fixed;
     height: 50px;
     bottom: 0;
-    z-index: 2;
+    z-index: 1001;
     left: 0;
     right: 0;
 }

--- a/resources/assets/style/sass/task-detail.scss
+++ b/resources/assets/style/sass/task-detail.scss
@@ -120,7 +120,7 @@
     position: absolute;
     top: 0;
     right: 5px;
-    z-index: 1000;
+    z-index: 10;
     font-size: 1.2em !important;
     line-height: 0.9em;
     font-weight: bold;


### PR DESCRIPTION
Six: dropzon
- prior dropzon image was overlapping to timer and footer, now solve this issue
issue link: https://gitlab.com/infy-apps/infy-tracker-issues/issues/119