### PR TITLE
fix(report): in report view page solve date issue

### DIFF
--- a/app/Models/Report.php
+++ b/app/Models/Report.php
@@ -99,7 +99,7 @@ class Report extends Model
 
         if ($startDate == $endDate) {
             return Carbon::parse($this->start_date)->format('jS M Y');
-        } elseif ($startDate->format('Y-m-d') == $startOfMonth && $endDate->format('Y-m-d') == $endOfMonth) {
+        } elseif ($startDate->format('Y-m-d') == $startOfMonth && $endDate->format('Y-m-d') == $endOfMonth && $startDate->month == $endDate->month) {
             return $startDate->format('M Y');
         } elseif ($startDate->month == $endDate->month) {
             return $startDate->format('jS').' - '.$endDate->format('jS M Y');


### PR DESCRIPTION
Bug Fix: Report view screen

- solve date issue in report view page
   Ex. If user selects date 1st-july-2019 to 31-Oct-2019 than in view page in header it display only **"July 2019"**, now this issue has been solved and date display as **"1st July - 31st Oct 2019"**
