### PR TITLE
refactor(time-entry): Remove one minute entry validation from time tracker

### DIFF
--- a/app/Repositories/TimeEntryRepository.php
+++ b/app/Repositories/TimeEntryRepository.php
@@ -140,7 +140,7 @@ class TimeEntryRepository extends BaseRepository
     /**
      * @param array $input
      *
-     * @return TimeEntry
+     * @return bool
      */
     public function store($input)
     {
@@ -148,9 +148,11 @@ class TimeEntryRepository extends BaseRepository
 
         $this->assignTaskToAdmin($input);
 
-        $timeEntry = TimeEntry::create($input);
+        if ($input['duration'] > 0) {
+            $timeEntry = TimeEntry::create($input);
+        }
 
-        return $timeEntry;
+        return true;
     }
 
     /**
@@ -195,7 +197,9 @@ class TimeEntryRepository extends BaseRepository
                 $input['end_time'] = '';
             }
         }
-        $this->update($input, $id);
+        if ($input['duration'] > 0) {
+            $this->update($input, $id);
+        }
 
         return true;
     }
@@ -226,10 +230,6 @@ class TimeEntryRepository extends BaseRepository
 
         if ($input['duration'] > 720) {
             throw new BadRequestHttpException('Time Entry must be less than 12 hours.');
-        }
-
-        if ($input['duration'] < 1) {
-            throw new BadRequestHttpException('Minimum Entry time should be 1 minute.');
         }
 
         $this->checkDuplicateEntry($input, $id);

--- a/tests/Controllers/Validations/TimeEntryControllerValidationTest.php
+++ b/tests/Controllers/Validations/TimeEntryControllerValidationTest.php
@@ -117,19 +117,19 @@ class TimeEntryControllerValidationTest extends TestCase
         $this->assertEquals('Time Entry must be less than 12 hours.', $response->exception->getMessage());
     }
 
-    /** @test */
-    public function test_add_time_entry_fail_when_duration_is_less_than_1_minutes()
-    {
-        $startTime = date('Y-m-d H:i:s', strtotime('-45 seconds'));
-        $endTime = date('Y-m-d H:i:s', strtotime('-10 seconds'));
-
-        $response = $this->post(
-            route('time-entries.store'),
-            $this->timeEntryInputs(['start_time' => $startTime, 'end_time' => $endTime])
-        );
-
-        $this->assertEquals('Minimum Entry time should be 1 minute.', $response->exception->getMessage());
-    }
+//    /** @test */
+//    public function test_add_time_entry_fail_when_duration_is_less_than_1_minutes()
+//    {
+//        $startTime = date('Y-m-d H:i:s', strtotime('-45 seconds'));
+//        $endTime = date('Y-m-d H:i:s', strtotime('-10 seconds'));
+//
+//        $response = $this->post(
+//            route('time-entries.store'),
+//            $this->timeEntryInputs(['start_time' => $startTime, 'end_time' => $endTime])
+//        );
+//
+//        $this->assertEquals('Minimum Entry time should be 1 minute.', $response->exception->getMessage());
+//    }
 
     /** @test */
     public function test_not_allow_to_add_duplicate_time_entry()
@@ -212,21 +212,21 @@ class TimeEntryControllerValidationTest extends TestCase
         $this->assertExceptionMessage($response, 'Time Entry must be less than 12 hours.');
     }
 
-    /** @test */
-    public function test_update_time_entry_fails_when_duration_is_less_than_1_minutes()
-    {
-        /** @var TimeEntry $timeEntry */
-        $timeEntry = factory(TimeEntry::class)->create(['user_id' => $this->defaultUserId]);
-        $startTime = date('Y-m-d H:i:s', strtotime('-45 seconds'));
-        $endTime = date('Y-m-d H:i:s', strtotime('-10 seconds'));
-
-        $response = $this->put(
-            route('time-entries.update', $timeEntry->id),
-            $this->timeEntryInputs(['start_time' => $startTime, 'end_time' => $endTime])
-        );
-
-        $this->assertExceptionMessage($response, 'Minimum Entry time should be 1 minute.');
-    }
+//    /** @test */
+//    public function test_update_time_entry_fails_when_duration_is_less_than_1_minutes()
+//    {
+//        /** @var TimeEntry $timeEntry */
+//        $timeEntry = factory(TimeEntry::class)->create(['user_id' => $this->defaultUserId]);
+//        $startTime = date('Y-m-d H:i:s', strtotime('-45 seconds'));
+//        $endTime = date('Y-m-d H:i:s', strtotime('-10 seconds'));
+//
+//        $response = $this->put(
+//            route('time-entries.update', $timeEntry->id),
+//            $this->timeEntryInputs(['start_time' => $startTime, 'end_time' => $endTime])
+//        );
+//
+//        $this->assertExceptionMessage($response, 'Minimum Entry time should be 1 minute.');
+//    }
 
     /** @test */
     public function test_not_allow_to_update_duplicate_time_entry()

--- a/tests/Controllers/Validations/TimeEntryControllerValidationTest.php
+++ b/tests/Controllers/Validations/TimeEntryControllerValidationTest.php
@@ -117,20 +117,6 @@ class TimeEntryControllerValidationTest extends TestCase
         $this->assertEquals('Time Entry must be less than 12 hours.', $response->exception->getMessage());
     }
 
-//    /** @test */
-//    public function test_add_time_entry_fail_when_duration_is_less_than_1_minutes()
-//    {
-//        $startTime = date('Y-m-d H:i:s', strtotime('-45 seconds'));
-//        $endTime = date('Y-m-d H:i:s', strtotime('-10 seconds'));
-//
-//        $response = $this->post(
-//            route('time-entries.store'),
-//            $this->timeEntryInputs(['start_time' => $startTime, 'end_time' => $endTime])
-//        );
-//
-//        $this->assertEquals('Minimum Entry time should be 1 minute.', $response->exception->getMessage());
-//    }
-
     /** @test */
     public function test_not_allow_to_add_duplicate_time_entry()
     {
@@ -211,22 +197,6 @@ class TimeEntryControllerValidationTest extends TestCase
 
         $this->assertExceptionMessage($response, 'Time Entry must be less than 12 hours.');
     }
-
-//    /** @test */
-//    public function test_update_time_entry_fails_when_duration_is_less_than_1_minutes()
-//    {
-//        /** @var TimeEntry $timeEntry */
-//        $timeEntry = factory(TimeEntry::class)->create(['user_id' => $this->defaultUserId]);
-//        $startTime = date('Y-m-d H:i:s', strtotime('-45 seconds'));
-//        $endTime = date('Y-m-d H:i:s', strtotime('-10 seconds'));
-//
-//        $response = $this->put(
-//            route('time-entries.update', $timeEntry->id),
-//            $this->timeEntryInputs(['start_time' => $startTime, 'end_time' => $endTime])
-//        );
-//
-//        $this->assertExceptionMessage($response, 'Minimum Entry time should be 1 minute.');
-//    }
 
     /** @test */
     public function test_not_allow_to_update_duplicate_time_entry()


### PR DESCRIPTION
### Changes

- timer can be stopped before 1 min but time-entry will not be created in data-base