### PR TITLE
fix(time-entry): date filter not working issue fixes

### DIFF
--- a/app/Queries/TimeEntryDataTable.php
+++ b/app/Queries/TimeEntryDataTable.php
@@ -52,6 +52,14 @@ class TimeEntryDataTable
                 }
             }
         );
+        $query->when(
+            isset($input['filter_date']) && !empty($input['filter_date']),
+            function (Builder $q) use ($input) {
+                $timeEntryDate = explode(' - ', $input['filter_date']);
+                $q->whereDate('start_time', '>=', $timeEntryDate[0])
+                    ->whereDate('end_time', '<=', $timeEntryDate[1]);
+            }
+        );
         if (!$user->can('manage_time_entries')) {
             return $query->OfCurrentUser();
         }
@@ -59,15 +67,6 @@ class TimeEntryDataTable
             isset($input['filter_user']) && !empty($input['filter_user']),
             function (Builder $q) use ($input) {
                 $q->where('user_id', $input['filter_user']);
-            }
-        );
-
-        $query->when(
-            isset($input['filter_date']) && !empty($input['filter_date']),
-            function (Builder $q) use ($input) {
-                $timeEntryDate = explode(' - ', $input['filter_date']);
-                $q->whereDate('start_time', '>=', $timeEntryDate[0])
-                    ->whereDate('end_time', '<=', $timeEntryDate[1]);
             }
         );
 

--- a/resources/assets/js/time_entries/time_entry.js
+++ b/resources/assets/js/time_entries/time_entry.js
@@ -5,6 +5,12 @@ let end = today.clone().endOf('month');
 let userId = $('#filterUser').val();
 const lastMonth = moment().startOf('month').subtract(1, 'days');
 
+$(document).ready(function () {
+    timeRange.val(start.format('YYYY-MM-DD') + ' - ' +
+            end.format('YYYY-MM-DD'));
+    tbl.ajax.reload();
+});
+
 $('#taskId,#editTaskId').select2({
     width: '100%',
     placeholder: 'Select Task',


### PR DESCRIPTION
**Changes**
- show only current month's time-entry by applying start and end date of month on page load
- date filter not working for the user who doesn't have 'manage_time_entries' issue fixed